### PR TITLE
Add SPDX expression support with structural canonicalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ A portable license ID matcher with command line interface and Python API.
   - `Apache-2+` → `Apache-2.0+` (abbreviated base canonicalised, `+` retained).
   - Bare deprecated IDs (e.g. `GPL-2.0`) resolved conservatively to `-only`
     when no surrounding context is available.
+- **SPDX License Expression support** (via [`py-spdx-license`][py-spdx-license]):
+  - Structural normalisation of `AND`/`OR` expressions: duplicate operands
+    collapse (`MIT AND MIT` → `MIT`) and operands are put in a consistent
+    order, making equivalent expressions compare equal.
+  - `WITH <exception>` expressions are validated and matched against the
+    SPDX exception list, not just the license list — e.g.
+    `licenseid match --id "MIT WITH Font-exception-2.0"` resolves correctly
+    even though it isn't a single license row.
+
+[py-spdx-license]: https://github.com/JPEWdev/py-spdx-license
 - **Unix philosophy**: Parseable, line-delimited CLI output.
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,3 +175,11 @@ markers = [
 extend-exclude = ["tests/fixtures/"]
 line-length = 88
 target-version = "py310"
+
+[tool.ruff.lint]
+# BLE001/S110: broad `except Exception` (bare or with a `pass` body) is used
+# deliberately here — CLI-boundary error handling and best-effort optional
+# integrations (Java/JPype consultation, speculative INI parsing) that must
+# degrade gracefully rather than propagate. Same stance as
+# `broad-exception-caught` in [tool.pylint.messages_control].
+ignore = ["BLE001", "S110"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 dependencies = [
     "beautifulsoup4>=4.15.0",
     "click>=8.4.2",
+    "py-spdx-license>=0.0.1",
     "rapidfuzz>=3.14.5",
     "requests>=2.33.0",
     "typing_extensions>=4.16.0",
@@ -109,6 +110,10 @@ warn_unreachable = true
 
 [[tool.mypy.overrides]]
 module = ["jpype", "jpype.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["py_spdx_license", "py_spdx_license.*"]
 ignore_missing_imports = true
 
 [tool.hatch.build.hooks.pitloom]

--- a/src/licenseid/__init__.py
+++ b/src/licenseid/__init__.py
@@ -9,8 +9,8 @@ SPDX License ID matcher package.
 
 __version__ = "0.3.2"
 
-from licenseid.matcher import AggregatedLicenseMatcher
 from licenseid.database import LicenseDatabase
+from licenseid.matcher import AggregatedLicenseMatcher
 from licenseid.normalize import normalize_text
 from licenseid.types import LicenseMatch, MatchRequest
 

--- a/src/licenseid/classify.py
+++ b/src/licenseid/classify.py
@@ -16,7 +16,6 @@ which AggregatedLicenseMatcher uses to choose a matching strategy.
 
 import os
 import re
-from typing import Optional
 
 # Detects -or-later granting language in mixed/source-file contexts.
 # Allows for comment characters (// # * ;) between "or" and
@@ -74,7 +73,7 @@ def has_or_later_language(text: str) -> bool:
     return bool(_RE_OR_LATER.search(text))
 
 
-def is_pure_license_text(file_path: Optional[str], text: str) -> bool:
+def is_pure_license_text(file_path: str | None, text: str) -> bool:
     """Return True if the content appears to be a standalone
     license document.
 

--- a/src/licenseid/cli.py
+++ b/src/licenseid/cli.py
@@ -11,7 +11,6 @@ import json
 import os
 import sys
 from datetime import datetime
-from typing import Optional
 
 import click
 
@@ -68,7 +67,7 @@ def check_db_staleness(database: LicenseDatabase) -> None:
 @click.option("--db", help="Path to the license database.")
 @click.option("--clear-cache", is_flag=True, help="Clear local cache and exit.")
 @click.pass_context
-def cli(ctx: click.Context, db: Optional[str], clear_cache: bool) -> None:
+def cli(ctx: click.Context, db: str | None, clear_cache: bool) -> None:
     """SPDX License ID matcher tool."""
     db_path = db or get_default_db_path()
     ctx.ensure_object(dict)
@@ -96,7 +95,7 @@ def cli(ctx: click.Context, db: Optional[str], clear_cache: bool) -> None:
 @click.pass_context
 def update(
     ctx: click.Context,
-    version: Optional[str],
+    version: str | None,
     force: bool,
     use_cache: bool,
 ) -> None:
@@ -131,9 +130,7 @@ def is_sqlite_uri(path: str) -> bool:
     return path.startswith("file:") or ":memory:" in path
 
 
-def get_input_content(
-    input_val: Optional[str], text: Optional[str]
-) -> tuple[str, bool]:
+def get_input_content(input_val: str | None, text: str | None) -> tuple[str, bool]:
     """
     Get input content and indicate if it's likely a file path/text vs an ID.
     Returns (content, is_text_or_file).
@@ -152,10 +149,10 @@ def get_input_content(
 
 def resolve_license_record(
     ctx: click.Context,
-    input_val: Optional[str],
-    text: Optional[str],
-    id_val: Optional[str] = None,
-) -> Optional[LicenseDetails]:
+    input_val: str | None,
+    text: str | None,
+    id_val: str | None = None,
+) -> LicenseDetails | None:
     """Helper to resolve a license from CLI arguments (implements Smart Logic)."""
     db_path = ctx.obj["db_path"]
     if not os.path.exists(db_path) and not is_sqlite_uri(db_path):
@@ -224,9 +221,9 @@ def resolve_license_record(
 @click.pass_context
 def match(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     ctx: click.Context,
-    input_val: Optional[str],
-    text: Optional[str],
-    id_val: Optional[str],
+    input_val: str | None,
+    text: str | None,
+    id_val: str | None,
     json_output: bool,
     threshold: float,
     top: int,
@@ -314,9 +311,9 @@ def match(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 @click.pass_context
 def is_osi(
     ctx: click.Context,
-    input_val: Optional[str],
-    text: Optional[str],
-    id_val: Optional[str],
+    input_val: str | None,
+    text: str | None,
+    id_val: str | None,
 ) -> None:
     """True if the license is OSI-approved."""
     record = resolve_license_record(ctx, input_val, text, id_val)
@@ -334,9 +331,9 @@ def is_osi(
 @click.pass_context
 def is_fsf(
     ctx: click.Context,
-    input_val: Optional[str],
-    text: Optional[str],
-    id_val: Optional[str],
+    input_val: str | None,
+    text: str | None,
+    id_val: str | None,
 ) -> None:
     """True if the license is FSF-libre."""
     record = resolve_license_record(ctx, input_val, text, id_val)
@@ -354,9 +351,9 @@ def is_fsf(
 @click.pass_context
 def is_open(
     ctx: click.Context,
-    input_val: Optional[str],
-    text: Optional[str],
-    id_val: Optional[str],
+    input_val: str | None,
+    text: str | None,
+    id_val: str | None,
 ) -> None:
     """True if the license is OSI-approved OR FSF-libre."""
     record = resolve_license_record(ctx, input_val, text, id_val)
@@ -374,9 +371,9 @@ def is_open(
 @click.pass_context
 def is_free(  # pylint: disable=unused-argument
     ctx: click.Context,
-    input_val: Optional[str],
-    text: Optional[str],
-    id_val: Optional[str],
+    input_val: str | None,
+    text: str | None,
+    id_val: str | None,
 ) -> None:
     """Alias for is-open."""
     ctx.forward(is_open)
@@ -389,9 +386,9 @@ def is_free(  # pylint: disable=unused-argument
 @click.pass_context
 def is_spdx_cmd(
     ctx: click.Context,
-    input_val: Optional[str],
-    text: Optional[str],
-    id_val: Optional[str],
+    input_val: str | None,
+    text: str | None,
+    id_val: str | None,
 ) -> None:
     """True if the license is in the SPDX License List."""
     record = resolve_license_record(ctx, input_val, text, id_val)

--- a/src/licenseid/cli.py
+++ b/src/licenseid/cli.py
@@ -10,7 +10,7 @@ Command-line interface for the licenseid tool.
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import click
 
@@ -52,7 +52,14 @@ def check_db_staleness(database: LicenseDatabase) -> None:
     if last_check:
         try:
             last_check_dt = datetime.fromisoformat(last_check)
-            days_old = (datetime.now() - last_check_dt).days
+            if last_check_dt.tzinfo is None:
+                # Databases written before this timestamp became
+                # tz-aware stored a naive local-time value; treat it as
+                # UTC rather than crashing on the subtraction below (this
+                # is only a rough 6-month staleness check, not something
+                # that needs to account for the original local offset).
+                last_check_dt = last_check_dt.replace(tzinfo=timezone.utc)
+            days_old = (datetime.now(timezone.utc) - last_check_dt).days
             if days_old > 182:  # Approx 6 months
                 click.echo(
                     f"WARNING: License database is {days_old} days old. "

--- a/src/licenseid/database.py
+++ b/src/licenseid/database.py
@@ -15,7 +15,7 @@ import tarfile
 import tempfile
 import xml.etree.ElementTree as ET
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 
@@ -497,7 +497,7 @@ class LicenseDatabase:
                 conn.execute("DELETE FROM db_metadata")
                 conn.execute("DELETE FROM license_fingerprints")
 
-                now = datetime.now().isoformat()
+                now = datetime.now(timezone.utc).isoformat()
                 metadata_items: list[tuple[str, str]] = [
                     ("license_list_version", list_version),
                     ("release_date", release_date or ""),

--- a/src/licenseid/database.py
+++ b/src/licenseid/database.py
@@ -17,7 +17,7 @@ import xml.etree.ElementTree as ET
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, cast
+from typing import cast
 
 from licenseid.normalize import normalize_text
 from licenseid.types import (
@@ -36,13 +36,13 @@ from licenseid.types import (
 _LicenseInsertRecord = tuple[
     str,
     str,
-    Optional[str],
+    str | None,
     bool,
     bool,
     bool,
     bool,
     bool,
-    Optional[str],
+    str | None,
     int,
     int,
     str,
@@ -85,7 +85,7 @@ class LicenseDatabase:
         # Check if it's an in-memory URI
         db_path_str = str(self.db_path)
         self.use_uri = "mode=memory" in db_path_str or db_path_str.startswith("file:")
-        self._keep_alive: Optional[sqlite3.Connection] = None
+        self._keep_alive: sqlite3.Connection | None = None
 
         if self.use_uri or db_path_str == ":memory:":
             # For in-memory databases, we must keep at least one connection
@@ -93,8 +93,8 @@ class LicenseDatabase:
             self._keep_alive = self._connect()
 
         self._init_db()
-        self._deprecated_mappings_cache: Optional[dict[str, str]] = None
-        self._names_and_ids_cache: Optional[list[LicenseNameId]] = None
+        self._deprecated_mappings_cache: dict[str, str] | None = None
+        self._names_and_ids_cache: list[LicenseNameId] | None = None
         self._norm_cols_backfilled = False
         self._check_normalization_version()
 
@@ -250,7 +250,7 @@ class LicenseDatabase:
 
     def update_from_remote(
         self,
-        version: Optional[str] = None,
+        version: str | None = None,
         force: bool = False,
         use_cache: bool = True,
     ) -> bool:
@@ -308,7 +308,7 @@ class LicenseDatabase:
         self,
         tar_path: Path,
         popularity_map: dict[str, int],
-        release_date: Optional[str],
+        release_date: str | None,
     ) -> None:
         """Extract tarball and update database records."""
         try:
@@ -359,7 +359,7 @@ class LicenseDatabase:
         root_dir: Path,
         popularity_map: dict[str, int],
         list_version: str,
-        release_date: Optional[str],
+        release_date: str | None,
         exceptions_data: list[SpdxExceptionEntry],
     ) -> None:
         """Execute database delete and insert operations."""
@@ -389,12 +389,12 @@ class LicenseDatabase:
     ) -> tuple[
         list[_LicenseInsertRecord],
         list[_IndexInsertRecord],
-        list[tuple[str, str, bool, Optional[str]]],
+        list[tuple[str, str, bool, str | None]],
     ]:
         """Build the in-memory record lists for insertion (no DB access)."""
         license_records: list[_LicenseInsertRecord] = []
         index_records: list[_IndexInsertRecord] = []
-        exception_records: list[tuple[str, str, bool, Optional[str]]] = []
+        exception_records: list[tuple[str, str, bool, str | None]] = []
 
         print("\nPreparing exception data...", end="", flush=True)
         # Build the superseded_by mapping at DB build time so runtime lookups
@@ -413,7 +413,7 @@ class LicenseDatabase:
         for i, lic in enumerate(licenses_data):
             # Recalculate record with superseded_by info
             is_deprecated = bool(lic.get("isDeprecatedLicenseId", False))
-            superseded_by: Optional[str] = None
+            superseded_by: str | None = None
             if is_deprecated:
                 dep_id = lic["licenseId"]
                 # SPDX '+' token: GPL-2.0+ → GPL-2.0-or-later (certain).
@@ -480,9 +480,9 @@ class LicenseDatabase:
         self,
         license_records: list[_LicenseInsertRecord],
         index_records: list[_IndexInsertRecord],
-        exception_records: list[tuple[str, str, bool, Optional[str]]],
+        exception_records: list[tuple[str, str, bool, str | None]],
         list_version: str,
-        release_date: Optional[str],
+        release_date: str | None,
     ) -> None:
         """Replace all license/exception/metadata rows in a single transaction."""
         print(f"\nInserting {len(license_records)} records into database...")
@@ -543,8 +543,8 @@ class LicenseDatabase:
         root_dir: Path,
         popularity_map: dict[str, int],
         is_deprecated: bool = False,
-        superseded_by: Optional[str] = None,
-    ) -> Optional[tuple[_LicenseInsertRecord, _IndexInsertRecord]]:
+        superseded_by: str | None = None,
+    ) -> tuple[_LicenseInsertRecord, _IndexInsertRecord] | None:
         """Prepare license data for insertion."""
         license_id = lic["licenseId"]
         text_path = root_dir / "text" / f"{license_id}.txt"
@@ -591,7 +591,7 @@ class LicenseDatabase:
         index_record: _IndexInsertRecord = (license_id, fingerprint)
         return license_record, index_record
 
-    def _create_fingerprint(self, text: str, xml_content: Optional[str] = None) -> str:
+    def _create_fingerprint(self, text: str, xml_content: str | None = None) -> str:
         """Create a search fingerprint by removing optional parts and normalizing."""
         if xml_content:
             try:
@@ -778,7 +778,7 @@ class LicenseDatabase:
             except sqlite3.OperationalError:
                 return []
 
-    def get_license_details(self, license_id: str) -> Optional[LicenseDetails]:
+    def get_license_details(self, license_id: str) -> LicenseDetails | None:
         """Get full metadata for a license (case-insensitive lookup)."""
         clean_id = license_id.strip()
         with self._connect() as conn:
@@ -791,7 +791,7 @@ class LicenseDatabase:
                 return None
             return self._cast_license_details(row)
 
-    def get_license_by_name(self, name: str) -> Optional[LicenseDetails]:
+    def get_license_by_name(self, name: str) -> LicenseDetails | None:
         """Get full metadata for a license by its full name (case-insensitive)."""
         clean_name = name.strip()
         if not clean_name:
@@ -806,7 +806,7 @@ class LicenseDatabase:
                 return None
             return self._cast_license_details(row)
 
-    def get_exception_details(self, exception_id: str) -> Optional[ExceptionDetails]:
+    def get_exception_details(self, exception_id: str) -> ExceptionDetails | None:
         """Get full metadata for an exception (case-insensitive lookup)."""
         clean_id = exception_id.strip()
         with self._connect() as conn:
@@ -819,7 +819,7 @@ class LicenseDatabase:
                 return None
             return self._cast_exception_details(row)
 
-    def get_license_by_id_prefix(self, prefix: str) -> Optional[LicenseDetails]:
+    def get_license_by_id_prefix(self, prefix: str) -> LicenseDetails | None:
         """Return the best (shortest) active license whose ID starts with *prefix*.
 
         Used to canonicalise abbreviated IDs such as ``"Apache-2"`` →

--- a/src/licenseid/identifiers.py
+++ b/src/licenseid/identifiers.py
@@ -85,14 +85,18 @@ _BARE_TO_OR_LATER: dict[str, str] = {
 #   "or (at your option) any later", "or newer",
 #   "any later version" (standalone)
 # Reference: GPL preamble boilerplate and SPDX matching guidelines
-_OR_LATER_RE = re.compile(
+_RE_OR_LATER = re.compile(
     r"\bor\s+(?:\([^)]{0,50}\)\s+)?(?:a\s+|any\s+)?(?:later|newer)\b"
     r"|\bany\s+later\s+version\b",
     re.IGNORECASE,
 )
 # "only" is a common English word; it is checked in a narrow 50-char window
 # AFTER the ID to avoid false positives from unrelated uses.
-_ONLY_RE = re.compile(r"\bonly\b", re.IGNORECASE)
+_RE_ONLY = re.compile(r"\bonly\b", re.IGNORECASE)
+
+# Tokenizer for SPDX license expressions: reserved operators/parens, or a
+# run of identifier characters (letters, digits, dots, hyphens).
+_RE_TOKEN = re.compile(r"\(|\)|AND|OR|WITH|\+|[a-zA-Z0-9.-]+", re.IGNORECASE)
 
 
 def disambiguate_deprecated_id(text: str) -> Optional[str]:
@@ -135,13 +139,13 @@ def disambiguate_deprecated_id(text: str) -> Optional[str]:
         start = max(0, m.start() - 150)
         end = min(len(text), m.end() + 150)
         window = text[start:end]
-        if _OR_LATER_RE.search(window):
+        if _RE_OR_LATER.search(window):
             return _BARE_TO_OR_LATER.get(dep_id)
 
         # Narrow window (50 chars after the ID) for "only" to reduce false
         # positives from common uses like "only if", "not only", etc.
         after = text[m.end() : m.end() + 50]
-        if _ONLY_RE.search(after):
+        if _RE_ONLY.search(after):
             return DEPRECATED_BARE_LICENSE_IDS[dep_id]
 
         # ID found but no disambiguating phrase — caller applies fallback.
@@ -165,9 +169,11 @@ def normalize_identifier(identifier: str, db: Optional[LicenseDatabase] = None) 
     if disambiguated:
         return disambiguated
 
-    # 1. Handle full expression parsing if AND/OR/WITH/+/( are present
-    upper_ident = identifier.upper()
-    if any(op in upper_ident for op in ["AND", "OR", "WITH", "+", "("]):
+    # 1. Handle full expression parsing if AND/OR/WITH/+/( are present as
+    # genuine operators/parens, not merely as a substring of a single ID's
+    # own name (e.g. the "or" in "GPL-2.0-or-later", or "and"/"or"/"with"
+    # occurring inside a LicenseRef- name).
+    if _is_expression(identifier):
         return _normalize_expression(identifier, db)
 
     # 2. Handle single ID normalization
@@ -280,14 +286,41 @@ def _normalize_exception_id(exc_id: str, db: Optional[LicenseDatabase] = None) -
     return exc_id
 
 
+def _tokenize_expression(expression: str) -> list[str]:
+    """Tokenize an SPDX license expression into reserved tokens
+    (``(``, ``)``, ``AND``, ``OR``, ``WITH``, ``+``) and identifiers.
+
+    Identifiers can contain letters, numbers, dots, and hyphens; the
+    identifier alternative's greedy ``+`` quantifier always consumes a full
+    contiguous run of those characters starting from its first character,
+    so a real ID that contains "and"/"or"/"with" as a substring of its own
+    name (e.g. the "-or-later" suffix, or a custom LicenseRef- name) is
+    always captured whole, never split at the embedded operator word.
+    """
+    return _RE_TOKEN.findall(expression)
+
+
+def _is_expression(identifier: str) -> bool:
+    """True if *identifier* is a real multi-part SPDX expression — contains
+    AND/OR/WITH as a genuine operator, ``+``, or parentheses — rather than a
+    single plain ID.
+
+    A plain substring check (e.g. ``"OR" in identifier.upper()``) misfires
+    on single IDs that happen to contain "and"/"or"/"with" inside their own
+    name (``GPL-2.0-or-later``, or a LicenseRef name like
+    ``LicenseRef-BRANDing-1.0``). Tokenizing first avoids that: such names
+    always come back as a single token.
+    """
+    tokens = _tokenize_expression(identifier)
+    if len(tokens) != 1:
+        return True
+    token = tokens[0]
+    return token in ("(", ")") or token.upper() in ("AND", "OR", "WITH")
+
+
 def _normalize_expression(expression: str, db: Optional[LicenseDatabase] = None) -> str:
     """Parses and normalises an SPDX License Expression."""
-    # Tokenize: keeping separators and identifiers
-    # Identifiers can contain letters, numbers, dots, and hyphens.
-    # "+" is a separate operator that attaches to an ID.
-    tokens = re.findall(
-        r"\(|\)|AND|OR|WITH|\+|[a-zA-Z0-9.-]+", expression, re.IGNORECASE
-    )
+    tokens = _tokenize_expression(expression)
 
     # 1. Pre-process to attach "+" to identifiers
     # This ensures "GPL-2.0" "+" becomes "GPL-2.0+" before normalization

--- a/src/licenseid/identifiers.py
+++ b/src/licenseid/identifiers.py
@@ -301,21 +301,27 @@ def _tokenize_expression(expression: str) -> list[str]:
 
 
 def _is_expression(identifier: str) -> bool:
-    """True if *identifier* is a real multi-part SPDX expression — contains
-    AND/OR/WITH as a genuine operator, ``+``, or parentheses — rather than a
-    single plain ID.
+    """True if *identifier* is a real SPDX expression — contains AND/OR/WITH
+    as a genuine operator, ``+``, or parentheses — rather than a single
+    plain ID or unrecognised garbage.
 
     A plain substring check (e.g. ``"OR" in identifier.upper()``) misfires
     on single IDs that happen to contain "and"/"or"/"with" inside their own
     name (``GPL-2.0-or-later``, or a LicenseRef name like
     ``LicenseRef-BRANDing-1.0``). Tokenizing first avoids that: such names
     always come back as a single token.
+
+    Checking for *any* reserved token — not just "more than one token" —
+    also keeps malformed multi-word input with no real operator (e.g.
+    ``"n M z"``, or whitespace-/symbol-only garbage, which tokenizes to
+    zero tokens) on the single-ID passthrough path, matching the previous
+    substring-check behaviour, rather than having it silently reformatted
+    (or reduced to "") by ``_normalize_expression``.
     """
-    tokens = _tokenize_expression(identifier)
-    if len(tokens) != 1:
-        return True
-    token = tokens[0]
-    return token in ("(", ")") or token.upper() in ("AND", "OR", "WITH")
+    return any(
+        token in ("(", ")", "+") or token.upper() in ("AND", "OR", "WITH")
+        for token in _tokenize_expression(identifier)
+    )
 
 
 def _normalize_expression(expression: str, db: Optional[LicenseDatabase] = None) -> str:

--- a/src/licenseid/identifiers.py
+++ b/src/licenseid/identifiers.py
@@ -8,7 +8,9 @@ SPDX Identifier and Expression normalization and validation.
 """
 
 import re
-from typing import Optional
+from typing import Optional, cast
+
+import py_spdx_license
 
 from licenseid.database import LicenseDatabase
 
@@ -105,7 +107,13 @@ def disambiguate_deprecated_id(text: str) -> Optional[str]:
     """
     # Sort longest IDs first so e.g. "LGPL-2.1" is tried before "LGPL-2".
     for dep_id in sorted(DEPRECATED_BARE_LICENSE_IDS, key=len, reverse=True):
-        m = re.search(r"\b" + re.escape(dep_id) + r"\b", text, re.IGNORECASE)
+        # (?![\w.-]) (not just \b) so a bare ID isn't matched as a prefix of
+        # an already-canonical suffixed ID it's contained in, e.g. "GPL-2.0"
+        # inside "GPL-2.0-only" or "GPL-2.0-or-later" — "\b" alone treats
+        # the boundary before "-" as a word boundary and would match, then
+        # the "-only"/"-or-later" suffix itself falsely satisfies the prose
+        # disambiguation checks below.
+        m = re.search(r"\b" + re.escape(dep_id) + r"(?![\w.-])", text, re.IGNORECASE)
         if not m:
             continue
 
@@ -228,6 +236,37 @@ def _normalize_single_id(
     return lic_id
 
 
+def _normalize_exception_id(exc_id: str, db: Optional[LicenseDatabase] = None) -> str:
+    """Normalises a single SPDX License Exception ID (the right-hand side of
+    a ``WITH`` operator).
+
+    Unlike license IDs, exceptions have their own DB table
+    (``get_exception_details`` / the exception half of
+    ``get_deprecated_mappings``); looking them up via the license-oriented
+    ``_normalize_single_id`` would never find a match and silently return the
+    ID unchanged, including its casing.
+    """
+    if not db:
+        return exc_id
+
+    mappings = db.get_deprecated_mappings()
+    normalized = mappings.get(exc_id)
+    if not normalized:
+        exc_id_upper = exc_id.upper()
+        for dep_id, canonical in mappings.items():
+            if dep_id.upper() == exc_id_upper:
+                normalized = canonical
+                break
+    if normalized:
+        return normalized
+
+    details = db.get_exception_details(exc_id)
+    if details:
+        return details["exception_id"]
+
+    return exc_id
+
+
 def _normalize_expression(expression: str, db: Optional[LicenseDatabase] = None) -> str:
     """Parses and normalises an SPDX License Expression."""
     # Tokenize: keeping separators and identifiers
@@ -254,15 +293,22 @@ def _normalize_expression(expression: str, db: Optional[LicenseDatabase] = None)
             i += 1
 
     normalized_tokens = []
+    prev_upper = ""
     for token in combined_tokens:
         upper_token = token.upper()
         if upper_token in ("AND", "OR", "WITH"):
             normalized_tokens.append(upper_token)
         elif token in ("(", ")"):
             normalized_tokens.append(token)
+        elif prev_upper == "WITH":
+            # The right-hand side of WITH is an exception ID, not a license
+            # ID — it has its own DB table/casing and must not be run
+            # through the license-oriented normalizer.
+            normalized_tokens.append(_normalize_exception_id(token, db))
         else:
             # It's an identifier (possibly with + already attached)
             normalized_tokens.append(_normalize_single_id(token, db))
+        prev_upper = upper_token
 
     # Reconstruct the expression with proper spacing,
     # handling parentheses without extra spaces.
@@ -277,4 +323,25 @@ def _normalize_expression(expression: str, db: Optional[LicenseDatabase] = None)
         else:
             expr += " " + part
 
-    return expr
+    return _canonicalize_expression(expr)
+
+
+def _canonicalize_expression(expr: str) -> str:
+    """Best-effort structural canonicalization via ``py_spdx_license``.
+
+    Builds a real AST from the (already ID-normalized) expression and uses
+    its ``sort()`` to de-duplicate identical AND/OR operands and produce a
+    consistent operand ordering (e.g. ``MIT AND MIT`` -> ``MIT``).
+
+    ``py_spdx_license`` doesn't support every string ``_normalize_expression``
+    can produce — notably the legacy ``license-id"+"`` form (e.g.
+    ``CDDL-1.0+``) that has no ``-or-later`` equivalent — and its bundled
+    license/exception list is a point-in-time snapshot that can lag behind
+    this project's live-downloaded database. Any failure here just means the
+    string keeps its original (non-deduplicated, non-reordered) form.
+    """
+    try:
+        ast = py_spdx_license.parse(expr, allow_unknown=True)
+        return cast(str, ast.sort().to_string())
+    except Exception:  # pylint: disable=broad-exception-caught
+        return expr

--- a/src/licenseid/identifiers.py
+++ b/src/licenseid/identifiers.py
@@ -8,7 +8,7 @@ SPDX Identifier and Expression normalization and validation.
 """
 
 import re
-from typing import Optional, cast
+from typing import cast
 
 import py_spdx_license
 
@@ -99,7 +99,7 @@ _RE_ONLY = re.compile(r"\bonly\b", re.IGNORECASE)
 _RE_TOKEN = re.compile(r"\(|\)|AND|OR|WITH|\+|[a-zA-Z0-9.-]+", re.IGNORECASE)
 
 
-def disambiguate_deprecated_id(text: str) -> Optional[str]:
+def disambiguate_deprecated_id(text: str) -> str | None:
     """
     Scan *text* for a bare deprecated SPDX ID and a surrounding prose phrase
     that resolves the ``-only`` / ``-or-later`` ambiguity.
@@ -154,7 +154,7 @@ def disambiguate_deprecated_id(text: str) -> Optional[str]:
     return None
 
 
-def normalize_identifier(identifier: str, db: Optional[LicenseDatabase] = None) -> str:
+def normalize_identifier(identifier: str, db: LicenseDatabase | None = None) -> str:
     """
     Normalises a single SPDX License ID or a full License Expression.
     """
@@ -183,7 +183,7 @@ def normalize_identifier(identifier: str, db: Optional[LicenseDatabase] = None) 
 # pylint: disable=too-many-branches
 def _normalize_single_id(
     lic_id: str,
-    db: Optional[LicenseDatabase] = None,
+    db: LicenseDatabase | None = None,
 ) -> str:
     """Normalises a single license or exception ID."""
     # 1. Database lookup (most accurate/up-to-date)
@@ -255,7 +255,7 @@ def _normalize_single_id(
     return lic_id
 
 
-def _normalize_exception_id(exc_id: str, db: Optional[LicenseDatabase] = None) -> str:
+def _normalize_exception_id(exc_id: str, db: LicenseDatabase | None = None) -> str:
     """Normalises a single SPDX License Exception ID (the right-hand side of
     a ``WITH`` operator).
 
@@ -324,7 +324,7 @@ def _is_expression(identifier: str) -> bool:
     )
 
 
-def _normalize_expression(expression: str, db: Optional[LicenseDatabase] = None) -> str:
+def _normalize_expression(expression: str, db: LicenseDatabase | None = None) -> str:
     """Parses and normalises an SPDX License Expression."""
     tokens = _tokenize_expression(expression)
 

--- a/src/licenseid/identifiers.py
+++ b/src/licenseid/identifiers.py
@@ -339,6 +339,11 @@ def _canonicalize_expression(expr: str) -> str:
     license/exception list is a point-in-time snapshot that can lag behind
     this project's live-downloaded database. Any failure here just means the
     string keeps its original (non-deduplicated, non-reordered) form.
+
+    The ``"+"`` limitation is tracked upstream at
+    https://github.com/JPEWdev/py-spdx-license/issues/1 — once it's natively
+    supported there, this fallback (and CDDL-1.0-style test cases) can be
+    revisited.
     """
     try:
         ast = py_spdx_license.parse(expr, allow_unknown=True)

--- a/src/licenseid/identifiers.py
+++ b/src/licenseid/identifiers.py
@@ -14,6 +14,16 @@ import py_spdx_license
 
 from licenseid.database import LicenseDatabase
 
+# Defensive cap on the number of AND/OR/WITH operators an expression may
+# have before we attempt py_spdx_license's structural sort()/dedup pass.
+# sort() has been observed to blow up well past polynomially — seconds of
+# CPU time past roughly 150 unique AND/OR operands in an otherwise flat
+# chain — for large expressions; this is not an SPDX grammar limit. Real
+# SPDX expressions are virtually never this large, so expressions past the
+# cap just skip canonicalization rather than risking a slow/blocking call
+# on a pathological or adversarial one.
+_MAX_CANONICALIZE_OPERATORS = 40
+
 # Deprecated SPDX License IDs using the '+' expression token.
 # The SPDX '+' operator means "or any later version" (SPDX Spec §10.1).
 # These can be resolved to canonical form with certainty because the '+'
@@ -107,13 +117,16 @@ def disambiguate_deprecated_id(text: str) -> Optional[str]:
     """
     # Sort longest IDs first so e.g. "LGPL-2.1" is tried before "LGPL-2".
     for dep_id in sorted(DEPRECATED_BARE_LICENSE_IDS, key=len, reverse=True):
-        # (?![\w.-]) (not just \b) so a bare ID isn't matched as a prefix of
+        # (?![\w-]) (not just \b) so a bare ID isn't matched as a prefix of
         # an already-canonical suffixed ID it's contained in, e.g. "GPL-2.0"
         # inside "GPL-2.0-only" or "GPL-2.0-or-later" — "\b" alone treats
         # the boundary before "-" as a word boundary and would match, then
         # the "-only"/"-or-later" suffix itself falsely satisfies the prose
-        # disambiguation checks below.
-        m = re.search(r"\b" + re.escape(dep_id) + r"(?![\w.-])", text, re.IGNORECASE)
+        # disambiguation checks below. "." is deliberately not excluded here:
+        # both real suffixes start with "-", and excluding "." too would
+        # reject a bare ID immediately followed by sentence punctuation
+        # (e.g. "...licensed under GPL-2.0. This version only.").
+        m = re.search(r"\b" + re.escape(dep_id) + r"(?![\w-])", text, re.IGNORECASE)
         if not m:
             continue
 
@@ -322,6 +335,10 @@ def _normalize_expression(expression: str, db: Optional[LicenseDatabase] = None)
             expr += part
         else:
             expr += " " + part
+
+    operator_count = sum(1 for t in normalized_tokens if t in ("AND", "OR", "WITH"))
+    if operator_count > _MAX_CANONICALIZE_OPERATORS:
+        return expr
 
     return _canonicalize_expression(expr)
 

--- a/src/licenseid/identifiers.py
+++ b/src/licenseid/identifiers.py
@@ -368,9 +368,7 @@ def _normalize_expression(expression: str, db: LicenseDatabase | None = None) ->
     for i, part in enumerate(normalized_tokens):
         if i == 0:
             expr = part
-        elif part == ")":
-            expr += part
-        elif normalized_tokens[i - 1] == "(":
+        elif part == ")" or normalized_tokens[i - 1] == "(":
             expr += part
         else:
             expr += " " + part

--- a/src/licenseid/markers.py
+++ b/src/licenseid/markers.py
@@ -8,7 +8,6 @@
 import json
 import os
 import re
-from typing import Optional
 
 from licenseid.database import LicenseDatabase
 from licenseid.identifiers import normalize_identifier
@@ -94,9 +93,7 @@ class MarkerDetector:
     def __init__(self, db: LicenseDatabase):
         self.db = db
 
-    def detect(
-        self, text: str, file_path: Optional[str] = None
-    ) -> list[CandidateMatch]:
+    def detect(self, text: str, file_path: str | None = None) -> list[CandidateMatch]:
         """Detect license markers in the given text, deduplicating by license_id."""
         seen: set[str] = set()
         result: list[CandidateMatch] = []
@@ -402,11 +399,11 @@ class MarkerDetector:
                     candidates.append(self.to_candidate(details, 0.9))
         return candidates
 
-    def _extract_license_from_lines(self, lines: list[str]) -> Optional[LicenseDetails]:
+    def _extract_license_from_lines(self, lines: list[str]) -> LicenseDetails | None:
         """Try to identify a license from a block of lines near a heading."""
         cleaned = [line.strip() for line in lines]
 
-        def _try(text: str) -> Optional[LicenseDetails]:
+        def _try(text: str) -> LicenseDetails | None:
             # Skip decorative separator lines (all "=", "-", "*", "#", or space)
             if not text or re.match(r"^[=\-*#\s]+$", text):
                 return None
@@ -438,7 +435,7 @@ class MarkerDetector:
 
         return None
 
-    def _extract_mentioned_license(self, text: str) -> Optional[str]:
+    def _extract_mentioned_license(self, text: str) -> str | None:
         """Extract and clean a license name/ID from 'under the X License' pattern."""
         m = self._RE_LICENSE_MENTION.search(text)
         if not m:
@@ -449,7 +446,7 @@ class MarkerDetector:
         candidate = re.sub(r"\s+Licen[sc]e[s]?\s*$", "", candidate, flags=re.IGNORECASE)
         return candidate.strip() if candidate.strip() else None
 
-    def _try_license_lookup(self, name: str) -> Optional[LicenseDetails]:
+    def _try_license_lookup(self, name: str) -> LicenseDetails | None:
         """Try multiple name/ID variants to resolve a license mention."""
         for candidate in self._name_variants(name):
             details = self.db.get_license_details(

--- a/src/licenseid/markers.py
+++ b/src/licenseid/markers.py
@@ -24,7 +24,7 @@ class MarkerDetector:
     # SPDX-License-Identifier tag.
     # Capture full expressions including spaces, parentheses, and operators.
     # We stop at common delimiters like quotes or line breaks.
-    RE_SPDX = re.compile(
+    _RE_SPDX = re.compile(
         r"SPDX-License-Identifier\s*[:=]\s*['\"]?"
         r"([a-zA-Z0-9.+-]+(?:\s+(?:AND|OR|WITH)\s+[a-zA-Z0-9.+-]+"
         r"|\s*\([^)]+\)|[a-zA-Z0-9.+-]+)*)",
@@ -33,48 +33,48 @@ class MarkerDetector:
 
     # Include + to handle SPDX-legacy notation like GPL-2.0+
     # Use [ \t]* (not \s*) to prevent matching across line breaks.
-    RE_LICENSE_FIELD = re.compile(
+    _RE_LICENSE_FIELD = re.compile(
         r"license[ \t]*[:=][ \t]*['\"]?([a-zA-Z0-9.+, \t-]+)['\"]?", re.IGNORECASE
     )
 
     # Heading patterns — allow optional words after "License/Licensing"
     # so "## License Agreement" and "## Licensing Information" both match.
-    RE_MD_HEADING = re.compile(
+    _RE_MD_HEADING = re.compile(
         r"^#+\s*Licens(?:e|ing)(?:\s+\w+)*\s*$", re.MULTILINE | re.IGNORECASE
     )
-    RE_UNDERLINE_HEADING = re.compile(
+    _RE_UNDERLINE_HEADING = re.compile(
         r"^\s*Licens(?:e|ing)(?:\s+\w+)*\s*\n\s*[=\-*#]{3,}\s*$",
         re.MULTILINE | re.IGNORECASE,
     )
-    RE_BOX_HEADING = re.compile(
+    _RE_BOX_HEADING = re.compile(
         r"^\s*[=\-*#]{3,}\s*\n\s*Licens(?:e|ing)(?:\s+\w+)*\s*\n\s*[=\-*#]{3,}\s*$",
         re.MULTILINE | re.IGNORECASE,
     )
-    RE_LINE_HEADING = re.compile(
+    _RE_LINE_HEADING = re.compile(
         r"^\s*Licens(?:e|ing)(?:\s+\w+)*\s*$", re.MULTILINE | re.IGNORECASE
     )
 
     # Font-exception-2.0: "As a special exception...embed this font..."
-    RE_FONT_EXCEPTION = re.compile(
+    _RE_FONT_EXCEPTION = re.compile(
         r"as\s+a\s+special\s+exception.{0,400}embed\s+this\s+font",
         re.IGNORECASE | re.DOTALL,
     )
 
     # GPL/LGPL/AGPL copyright notice header detection.
     # Matches "GNU [Lesser|Library|Affero] General Public License".
-    RE_GPL_FAMILY = re.compile(
+    _RE_GPL_FAMILY = re.compile(
         r"GNU\s+((?:Lesser|Library|Affero)\s+)?General\s+Public\s+License",
         re.IGNORECASE,
     )
     # Version number appearing in or near the license grant.
     # "either version 2" / "version 2.1" / "v3" etc.
-    RE_GPL_VERSION = re.compile(
+    _RE_GPL_VERSION = re.compile(
         r"(?:either\s+)?v(?:ersion)?\s*(\d+(?:\.\d+)?)",
         re.IGNORECASE,
     )
     # "or later" signals within the license grant window.
     # "either version" alone implies "or any later version" in GPL boilerplate.
-    RE_GPL_OR_LATER = re.compile(
+    _RE_GPL_OR_LATER = re.compile(
         r"or\s+\(?at\s+your\s+option\)?\s+any\s+later\s+version"
         r"|\beither\s+version\b",
         re.IGNORECASE,
@@ -84,7 +84,7 @@ class MarkerDetector:
     # "released under Apache License, Version 2.0", etc.
     # `\s+` (not `[ \t]+`) intentionally spans newlines so "licensed \nunder" matches.
     # Capture stops at end-of-line, opening paren, or sentence-terminating punctuation.
-    RE_LICENSE_MENTION = re.compile(
+    _RE_LICENSE_MENTION = re.compile(
         r"(?:licens(?:ed?|ing)|released?|distributed?)\s+under"
         r"(?:\s+the)?(?:\s+project'?s?)?"
         r"\s+([^\n;(]{2,100})",
@@ -209,7 +209,7 @@ class MarkerDetector:
         candidates: list[CandidateMatch] = []
 
         # 1. SPDX-License-Identifier
-        for match in self.RE_SPDX.finditer(text):
+        for match in self._RE_SPDX.finditer(text):
             lic_id = normalize_identifier(match.group(1).strip(), self.db)
             details = self.db.get_license_details(lic_id)
             if details:
@@ -232,7 +232,7 @@ class MarkerDetector:
                 )
 
         # 2. License metadata field (e.g. in package.json / pyproject.toml)
-        for match in self.RE_LICENSE_FIELD.finditer(text):
+        for match in self._RE_LICENSE_FIELD.finditer(text):
             val = normalize_identifier(match.group(1).strip(), self.db)
             if not val:
                 continue
@@ -271,7 +271,7 @@ class MarkerDetector:
                 "General Public License"
             )
 
-        for m in self.RE_GPL_FAMILY.finditer(text):
+        for m in self._RE_GPL_FAMILY.finditer(text):
             modifier = (m.group(1) or "").strip().lower()
 
             # Search for the version number and or-later signal within a window
@@ -279,7 +279,7 @@ class MarkerDetector:
             window_end = min(len(text), m.end() + 1000)
             window = text[m.start() : window_end]
 
-            ver_match = self.RE_GPL_VERSION.search(window)
+            ver_match = self._RE_GPL_VERSION.search(window)
             if not ver_match:
                 continue
 
@@ -287,7 +287,7 @@ class MarkerDetector:
             if "." not in version_str:
                 version_str += ".0"
 
-            or_later = bool(self.RE_GPL_OR_LATER.search(window))
+            or_later = bool(self._RE_GPL_OR_LATER.search(window))
 
             # Logic for appendix/terms: if the match is in a section that explains
             # "or later" but is not the grant itself, ignore the signal.
@@ -319,7 +319,7 @@ class MarkerDetector:
                 continue
 
             # Check for Font-exception-2.0 ("As a special exception...embed this font")
-            if family == "GPL" and self.RE_FONT_EXCEPTION.search(text):
+            if family == "GPL" and self._RE_FONT_EXCEPTION.search(text):
                 font_id = f"{license_id} WITH Font-exception-2.0"
                 score = 0.92 if or_later else 0.88
                 font_details = self.db.get_license_details(font_id)
@@ -440,7 +440,7 @@ class MarkerDetector:
 
     def _extract_mentioned_license(self, text: str) -> Optional[str]:
         """Extract and clean a license name/ID from 'under the X License' pattern."""
-        m = self.RE_LICENSE_MENTION.search(text)
+        m = self._RE_LICENSE_MENTION.search(text)
         if not m:
             return None
         # Truncate at sentence boundary then clean
@@ -514,7 +514,7 @@ class MarkerDetector:
         joined = re.sub(r"(?<!\n)\n(?!\n)", " ", text)
         candidates: list[CandidateMatch] = []
         seen: set[str] = set()
-        for m in self.RE_LICENSE_MENTION.finditer(joined):
+        for m in self._RE_LICENSE_MENTION.finditer(joined):
             # Truncate at sentence boundary (". " ends the license name phrase)
             raw = re.split(r"\.\s", m.group(1), maxsplit=1)[0].strip().rstrip(".,; ")
             raw = re.sub(r"\bproject'?s?\s+", "", raw, flags=re.IGNORECASE)
@@ -530,13 +530,13 @@ class MarkerDetector:
 
     def _is_heading(self, line: str, i: int, lines: list[str]) -> bool:
         """Helper to identify if a line is part of a license heading."""
-        if self.RE_MD_HEADING.match(line) or self.RE_LINE_HEADING.match(line):
+        if self._RE_MD_HEADING.match(line) or self._RE_LINE_HEADING.match(line):
             return True
-        if i + 1 < len(lines) and self.RE_UNDERLINE_HEADING.match(
+        if i + 1 < len(lines) and self._RE_UNDERLINE_HEADING.match(
             line + "\n" + lines[i + 1]
         ):
             return True
-        if 0 < i < len(lines) - 1 and self.RE_BOX_HEADING.match(
+        if 0 < i < len(lines) - 1 and self._RE_BOX_HEADING.match(
             lines[i - 1] + "\n" + line + "\n" + lines[i + 1]
         ):
             return True

--- a/src/licenseid/markers.py
+++ b/src/licenseid/markers.py
@@ -290,17 +290,23 @@ class MarkerDetector:
             # "or later" but is not the grant itself, ignore the signal.
             if or_later:
                 # 1. Check Appendix
-                if appendix_start != -1 and m.start() > appendix_start:
-                    if "one line to give the program's name" in window.lower():
-                        or_later = False
+                if (
+                    appendix_start != -1
+                    and m.start() > appendix_start
+                    and "one line to give the program's name" in window.lower()
+                ):
+                    or_later = False
 
                 # 2. Check Terms Explanation (Section 9/14)
-                if or_later and terms_explanation != -1:
-                    # If the match is within a reasonable distance of the terms
-                    # explanation (e.g. within the same paragraph),
-                    # it's likely just the terms.
-                    if abs(m.start() - terms_explanation) < 500:
-                        or_later = False
+                # If the match is within a reasonable distance of the terms
+                # explanation (e.g. within the same paragraph), it's likely
+                # just the terms.
+                if (
+                    or_later
+                    and terms_explanation != -1
+                    and abs(m.start() - terms_explanation) < 500
+                ):
+                    or_later = False
 
             if "lesser" in modifier or "library" in modifier:
                 family = "LGPL"
@@ -533,11 +539,12 @@ class MarkerDetector:
             line + "\n" + lines[i + 1]
         ):
             return True
-        if 0 < i < len(lines) - 1 and self._RE_BOX_HEADING.match(
-            lines[i - 1] + "\n" + line + "\n" + lines[i + 1]
-        ):
-            return True
-        return False
+        return bool(
+            0 < i < len(lines) - 1
+            and self._RE_BOX_HEADING.match(
+                lines[i - 1] + "\n" + line + "\n" + lines[i + 1]
+            )
+        )
 
     def _detect_first_line(self, text: str) -> list[CandidateMatch]:
         """Check if the first non-empty line is a known license ID or name."""

--- a/src/licenseid/matcher.py
+++ b/src/licenseid/matcher.py
@@ -263,10 +263,16 @@ class AggregatedLicenseMatcher:
         though it is perfectly valid. Parse it structurally, then validate
         each half against this project's own (live-downloaded) license and
         exception tables.
+
+        Catches broadly (not just ``ParseError``): py_spdx_license's AST
+        construction is a plain recursive tree walk with no depth guard, so
+        a pathological input (e.g. a very long ``AND``-chain passed
+        directly as ``license_id``) raises ``RecursionError`` rather than
+        ``ParseError``. Either way, it isn't a WITH match.
         """
         try:
             ast = py_spdx_license.parse(license_id, allow_unknown=True)
-        except py_spdx_license.ParseError:
+        except Exception:  # pylint: disable=broad-exception-caught
             return None
 
         if not isinstance(ast, py_spdx_license.WithOp):

--- a/src/licenseid/matcher.py
+++ b/src/licenseid/matcher.py
@@ -11,6 +11,7 @@ import os
 import shutil
 from typing import Any, Optional, cast
 
+import py_spdx_license
 from rapidfuzz import fuzz
 
 from licenseid.classify import has_or_later_language, is_pure_license_text
@@ -104,6 +105,9 @@ class AggregatedLicenseMatcher:
                         is_fsf_libre=details["is_fsf_libre"],
                     )
                 ]
+            with_match = self._match_with_expression(license_id)
+            if with_match:
+                return [with_match]
             return []
 
         # 2. File Path
@@ -249,6 +253,41 @@ class AggregatedLicenseMatcher:
 
         return cast(list[LicenseMatch], ranked)
 
+    def _match_with_expression(self, license_id: str) -> Optional[LicenseMatch]:
+        """Resolve a bare ``<license> WITH <exception>`` expression.
+
+        The ``licenses`` table only has rows for plain license IDs (plus a
+        handful of legacy hardcoded compound IDs), so a well-formed but
+        otherwise unseen expression like ``MIT WITH Font-exception-2.0``
+        would not be found by a direct ``get_license_details`` lookup even
+        though it is perfectly valid. Parse it structurally, then validate
+        each half against this project's own (live-downloaded) license and
+        exception tables.
+        """
+        try:
+            ast = py_spdx_license.parse(license_id, allow_unknown=True)
+        except py_spdx_license.ParseError:
+            return None
+
+        if not isinstance(ast, py_spdx_license.WithOp):
+            return None
+
+        lic_details = self.db.get_license_details(ast.license.ident)
+        exc_details = self.db.get_exception_details(ast.exception.ident)
+        if not lic_details or not exc_details:
+            return None
+
+        combined_id = f"{lic_details['license_id']} WITH {exc_details['exception_id']}"
+        return LicenseMatch(
+            license_id=combined_id,
+            score=1.0,
+            similarity=1.0,
+            coverage=1.0,
+            is_spdx=lic_details["is_spdx"],
+            is_osi_approved=lic_details["is_osi_approved"],
+            is_fsf_libre=lic_details["is_fsf_libre"],
+        )
+
     def _resolve_to_record(
         self,
         text: Optional[str] = None,
@@ -258,9 +297,30 @@ class AggregatedLicenseMatcher:
     ) -> Optional[LicenseDetails]:
         """Internal helper to resolve explicit inputs to a database record."""
         results = self.match(text, license_id=license_id, file_path=file_path)
-        if results and results[0]["score"] >= 0.85:
-            return self.db.get_license_details(results[0]["license_id"])
-        return None
+        if not results or results[0]["score"] < 0.85:
+            return None
+
+        top = results[0]
+        record = self.db.get_license_details(top["license_id"])
+        if record:
+            return record
+
+        # Composite "license WITH exception" matches aren't a single DB
+        # row (see _match_with_expression) — fall back to the flags match()
+        # already computed rather than reporting "unknown".
+        return cast(
+            LicenseDetails,
+            {
+                "license_id": top["license_id"],
+                "name": top["license_id"],
+                "is_spdx": top.get("is_spdx", False),
+                "is_osi_approved": top.get("is_osi_approved", False),
+                "is_fsf_libre": top.get("is_fsf_libre", False),
+                "is_high_usage": False,
+                "pop_score": 0,
+                "word_count": 0,
+            },
+        )
 
     def is_spdx(self, text: Optional[str] = None, **kwargs: Any) -> bool:
         """True if the license is in the SPDX License List."""

--- a/src/licenseid/matcher.py
+++ b/src/licenseid/matcher.py
@@ -9,7 +9,7 @@ Aggregated license matching logic using hybrid search.
 
 import os
 import shutil
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import py_spdx_license
 from rapidfuzz import fuzz
@@ -61,7 +61,7 @@ class AggregatedLicenseMatcher:
 
     def __init__(
         self,
-        db_path: Optional[str] = None,
+        db_path: str | None = None,
         enable_java: bool = False,
         enable_popularity: bool = False,
     ):
@@ -77,10 +77,10 @@ class AggregatedLicenseMatcher:
     # pylint: disable=too-many-locals
     def match(
         self,
-        text: Optional[str] = None,
+        text: str | None = None,
         *,
-        license_id: Optional[str] = None,
-        file_path: Optional[str] = None,
+        license_id: str | None = None,
+        file_path: str | None = None,
         **options: Any,
     ) -> list[LicenseMatch]:
         # pylint: disable=too-many-return-statements
@@ -253,7 +253,7 @@ class AggregatedLicenseMatcher:
 
         return cast(list[LicenseMatch], ranked)
 
-    def _match_with_expression(self, license_id: str) -> Optional[LicenseMatch]:
+    def _match_with_expression(self, license_id: str) -> LicenseMatch | None:
         """Resolve a bare ``<license> WITH <exception>`` expression.
 
         The ``licenses`` table only has rows for plain license IDs (plus a
@@ -296,11 +296,11 @@ class AggregatedLicenseMatcher:
 
     def _resolve_to_record(
         self,
-        text: Optional[str] = None,
+        text: str | None = None,
         *,
-        license_id: Optional[str] = None,
-        file_path: Optional[str] = None,
-    ) -> Optional[LicenseDetails]:
+        license_id: str | None = None,
+        file_path: str | None = None,
+    ) -> LicenseDetails | None:
         """Internal helper to resolve explicit inputs to a database record."""
         results = self.match(text, license_id=license_id, file_path=file_path)
         if not results or results[0]["score"] < 0.85:
@@ -328,22 +328,22 @@ class AggregatedLicenseMatcher:
             },
         )
 
-    def is_spdx(self, text: Optional[str] = None, **kwargs: Any) -> bool:
+    def is_spdx(self, text: str | None = None, **kwargs: Any) -> bool:
         """True if the license is in the SPDX License List."""
         record = self._resolve_to_record(text, **kwargs)
         return record is not None and record.get("is_spdx", False)
 
-    def is_osi(self, text: Optional[str] = None, **kwargs: Any) -> bool:
+    def is_osi(self, text: str | None = None, **kwargs: Any) -> bool:
         """True if the license is OSI-approved."""
         record = self._resolve_to_record(text, **kwargs)
         return record is not None and record.get("is_osi_approved", False)
 
-    def is_fsf(self, text: Optional[str] = None, **kwargs: Any) -> bool:
+    def is_fsf(self, text: str | None = None, **kwargs: Any) -> bool:
         """True if the license is FSF-libre."""
         record = self._resolve_to_record(text, **kwargs)
         return record is not None and record.get("is_fsf_libre", False)
 
-    def is_open(self, text: Optional[str] = None, **kwargs: Any) -> bool:
+    def is_open(self, text: str | None = None, **kwargs: Any) -> bool:
         """True if the license is OSI-approved OR FSF-libre."""
         record = self._resolve_to_record(text, **kwargs)
         if not record:
@@ -490,7 +490,7 @@ class AggregatedLicenseMatcher:
         candidates: list[CandidateMatch],
         norm_input: str,
         data: MatchRequest,
-        marker_boosts: Optional[dict[str, float]] = None,
+        marker_boosts: dict[str, float] | None = None,
         is_pure: bool = True,
     ) -> list[InternalMatch]:
         """Rank candidates using dynamic sliding window and

--- a/src/licenseid/matcher.py
+++ b/src/licenseid/matcher.py
@@ -455,12 +455,15 @@ class AggregatedLicenseMatcher:
             # Filtering logic using pre-fetched metadata
             if only_spdx and not cand.get("is_spdx", False):
                 continue
-            if only_common and not cand.get("is_high_usage", False):
-                if not (
+            if (
+                only_common
+                and not cand.get("is_high_usage", False)
+                and not (
                     cand.get("is_osi_approved", False)
                     or cand.get("is_fsf_libre", False)
-                ):
-                    continue
+                )
+            ):
+                continue
 
             filtered.append(cand)
 

--- a/src/licenseid/normalize.py
+++ b/src/licenseid/normalize.py
@@ -16,14 +16,14 @@ from typing import Final
 # Closing tags (</p>, </div>, ...) appear only in real HTML — unlike opening
 # tags, they are never used as plain-text placeholders such as <year> or
 # <organization> that appear in license templates.
-_HTML_TAG: Final = re.compile(r"</[a-z][a-z0-9]*\s*>", re.IGNORECASE)
+_RE_HTML_TAG: Final = re.compile(r"</[a-z][a-z0-9]*\s*>", re.IGNORECASE)
 
 # Guideline 2: Collapse any sequence of whitespace to a single space.
-_WHITESPACE: Final = re.compile(r"\s+")
+_RE_WHITESPACE: Final = re.compile(r"\s+")
 
 # Final punctuation sweep: remove anything left that is not alphanumeric or
 # whitespace, after the specific equivalence normalisations below have run.
-_NON_WORD: Final = re.compile(r"[^\w\s]")
+_RE_NON_WORD: Final = re.compile(r"[^\w\s]")
 
 # Guideline 4 (hyphens): any hyphen, dash, en dash, em dash, or similar
 # variant is considered equivalent.  The final punctuation sweep (step 12)
@@ -37,11 +37,11 @@ _NON_WORD: Final = re.compile(r"[^\w\s]")
 # second call to normalize_text() to behave differently from the first
 # (non-idempotent).  Folding hyphens to spaces here, before varietal
 # matching runs, keeps normalize_text() idempotent.
-_DASHES: Final = re.compile(r"[‐‑‒–—―−﹘﹣－-]")
+_RE_DASHES: Final = re.compile(r"[‐‑‒–—―−﹘﹣－-]")
 
 # Guideline 4 (quotes): any variation of quotations is considered
 # equivalent.  Normalise to ASCII single quote before stripping punctuation.
-_QUOTES: Final = re.compile(
+_RE_QUOTES: Final = re.compile(
     r'["«»'  # " « »
     r"‘’"  # ' '
     r"‚‛"  # ‚ ‛
@@ -56,7 +56,7 @@ _QUOTES: Final = re.compile(
 
 # Guideline 5a: code comment prefixes at the start of a line.
 # Covers: // /* ** * # ' (VB) REM -- -} *)
-_COMMENT_PREFIX: Final = re.compile(
+_RE_COMMENT_PREFIX: Final = re.compile(
     r"(?m)^[ \t]*"
     r"(?://|/\*+|\*\)"  # C/Java-style open & Pascal close
     r"|\*(?![\w*])"  # lone * continuation, but not ** or *word
@@ -71,17 +71,17 @@ _COMMENT_PREFIX: Final = re.compile(
 # A second, narrower comment-prefix stripper for a different call site:
 # matcher.py runs strip_comment_prefixes() on raw (not yet normalized) text
 # before FTS5 indexing/querying, to improve recall on Type 5 (comment-
-# wrapped) license notices — separately from _COMMENT_PREFIX above, which
+# wrapped) license notices — separately from _RE_COMMENT_PREFIX above, which
 # only runs inside normalize_text() itself as one step of the guideline
 # pipeline.  They are intentionally not merged into one regex: this one
 # covers fewer comment styles (no VB/BASIC/Lua/Haskell — not expected in
 # the source files this targets) but additionally strips trailing "*/"
-# block-comment closers, which _COMMENT_PREFIX has no equivalent for.
-_LINE_COMMENT_PREFIX: Final = re.compile(
+# block-comment closers, which _RE_COMMENT_PREFIX has no equivalent for.
+_RE_LINE_COMMENT_PREFIX: Final = re.compile(
     r"^[ \t]*(?://+|#+|;+|\*(?!/)|/\*)[ \t]?",
     re.MULTILINE,
 )
-_BLOCK_COMMENT_CLOSER: Final = re.compile(r"^[ \t]*\*/[ \t]*$", re.MULTILINE)
+_RE_BLOCK_COMMENT_CLOSER: Final = re.compile(r"^[ \t]*\*/[ \t]*$", re.MULTILINE)
 
 
 def strip_comment_prefixes(text: str) -> str:
@@ -92,19 +92,19 @@ def strip_comment_prefixes(text: str) -> str:
     removed.  Applied before FTS5 on source-file inputs to improve
     recall for Type 5 (comment-wrapped) license notices.
     """
-    stripped = _LINE_COMMENT_PREFIX.sub("", text)
-    stripped = _BLOCK_COMMENT_CLOSER.sub("", stripped)
+    stripped = _RE_LINE_COMMENT_PREFIX.sub("", text)
+    stripped = _RE_BLOCK_COMMENT_CLOSER.sub("", stripped)
     return stripped
 
 
 # Guideline 5b: runs of 3+ identical non-alphanumeric characters used as
 # visual separators (---, ===, ***, ___) carry no meaning.
-_SEPARATOR: Final = re.compile(r"([^\w\s])\1{2,}")
+_RE_SEPARATOR: Final = re.compile(r"([^\w\s])\1{2,}")
 
 # Guideline 6: bullets and list-item markers at the start of a line are
 # ignored.  Covers symbol bullets, "1." / "a." / "1)" style, "(1)" / "(a)"
 # style, and short roman numerals ("iv.").
-_BULLETS: Final = re.compile(
+_RE_BULLETS: Final = re.compile(
     r"(?m)^[ \t]*"
     r"(?:"
     r"[*\-•◦‣▪▸]"  # symbol bullets
@@ -171,14 +171,14 @@ _VARIETAL_WORDS: Final[dict[str, str]] = {
 # multiword phrases ("copyright owner", "per cent") win over any single-word
 # prefix; lookarounds instead of \b so the "&" entry (a non-word character)
 # also anchors correctly.
-_VARIETAL_RE: Final = re.compile(
+_RE_VARIETAL: Final = re.compile(
     r"(?<!\w)(?:"
     + "|".join(re.escape(v) for v in sorted(_VARIETAL_WORDS, key=len, reverse=True))
     + r")(?!\w)"
 )
 
 # Guideline 8: copyright symbol equivalence — © Ⓒ ⓒ and "(c)" are the same.
-_COPYRIGHT_SYMBOL: Final = re.compile(r"[©Ⓒⓒ]")
+_RE_COPYRIGHT_SYMBOL: Final = re.compile(r"[©Ⓒⓒ]")
 
 # Guideline 9: copyright notices are not part of the matchable text.
 # Two cases:
@@ -209,7 +209,7 @@ _COPYRIGHT_SYMBOL: Final = re.compile(r"[©Ⓒⓒ]")
 # "(?:[ \t]+\S+)" (horizontal whitespace, not \s) is what enforces the
 # newline stop: a "\n" can't satisfy "[ \t]+", so the repetition can't
 # continue past one even when the word-count budget isn't exhausted.
-_COPYRIGHT_NOTICE: Final = re.compile(
+_RE_COPYRIGHT_NOTICE: Final = re.compile(
     r"(?:"
     r"(?:[©Ⓒⓒ]|\(c\))(?:[ \t]+\S+){0,25}"
     r"|copyright(?=[ \t]+(?:\S+[ \t]+){0,10}?\S*(?:\d|[©Ⓒⓒ]|\(c\)|<year>))"
@@ -219,9 +219,9 @@ _COPYRIGHT_NOTICE: Final = re.compile(
 )
 
 # Guideline 12: http:// and https:// are equivalent.
-_HTTPS: Final = re.compile(r"https://")
+_RE_HTTPS: Final = re.compile(r"https://")
 
-# Guideline 9 (copyright notice removal) is implemented (_COPYRIGHT_NOTICE
+# Guideline 9 (copyright notice removal) is implemented (_RE_COPYRIGHT_NOTICE
 # above) but OFF by default.  A full corpus benchmark (bench_compare.py,
 # main vs a branch with this step enabled) showed a broad recall regression
 # (-0.72% overall; worst on mixed content and Tier 0.5/Tier 1 recall,
@@ -281,7 +281,7 @@ def normalize_text(text: str) -> str:
     3 is re-enabled, it stops being idempotent: copyright-notice detection
     is a bounded heuristic, not an exact parse of "the notice line" — it
     matches a "copyright"/"(c)"/"©" cue anywhere in the text (deliberately
-    not anchored to line start — see the _COPYRIGHT_NOTICE comment for
+    not anchored to line start — see the _RE_COPYRIGHT_NOTICE comment for
     why) and then deletes up to 25 following words, stopping early only if
     a real newline is hit first. On ordinary multi-line input this
     reliably isolates just the notice. But because normalize_text()
@@ -297,7 +297,7 @@ def normalize_text(text: str) -> str:
     """
     # 1. HTML to plain text.  Newline separator preserves line structure for
     # the line-based rules below (copyright notices, comments, bullets).
-    if _HTML_TAG.search(text):
+    if _RE_HTML_TAG.search(text):
         # Local import: bs4 costs ~30ms at import time and is only needed
         # for the (uncommon) HTML-input case, so it's not worth paying that
         # cost on every normalize_text() call / CLI startup.
@@ -308,43 +308,43 @@ def normalize_text(text: str) -> str:
 
     # 2. Code comment prefixes (per-line; must run before copyright notice
     # removal so a "# Copyright ..." header's line-start anchor is reachable)
-    text = _COMMENT_PREFIX.sub("", text)
+    text = _RE_COMMENT_PREFIX.sub("", text)
 
     # 3. Copyright notice removal (before lowercasing/punctuation strip so
     # the (c) / © / digit cues are still present).  See
     # _STRIP_COPYRIGHT_NOTICE for why this is off by default.
     if _STRIP_COPYRIGHT_NOTICE:
-        text = _COPYRIGHT_NOTICE.sub("", text)
+        text = _RE_COPYRIGHT_NOTICE.sub("", text)
 
     # 4. Repeated separator characters
-    text = _SEPARATOR.sub(" ", text)
+    text = _RE_SEPARATOR.sub(" ", text)
 
     # 5. Bullets and list markers (per-line)
-    text = _BULLETS.sub("", text)
+    text = _RE_BULLETS.sub("", text)
 
     # 6. URL protocol
-    text = _HTTPS.sub("http://", text)
+    text = _RE_HTTPS.sub("http://", text)
 
     # 7. Copyright symbol
-    text = _COPYRIGHT_SYMBOL.sub("(c)", text)
+    text = _RE_COPYRIGHT_SYMBOL.sub("(c)", text)
 
     # 8. Dashes / hyphens
-    text = _DASHES.sub(" ", text)
+    text = _RE_DASHES.sub(" ", text)
 
     # 9. Quotes
-    text = _QUOTES.sub("'", text)
+    text = _RE_QUOTES.sub("'", text)
 
     # 10. Case
     text = text.lower()
 
     # 11. Whitespace collapse (see docstring: must run before step 12)
-    text = _WHITESPACE.sub(" ", text).strip()
+    text = _RE_WHITESPACE.sub(" ", text).strip()
 
     # 12. Varietal word spelling (single pass; input is lowercase by now)
-    text = _VARIETAL_RE.sub(lambda m: _VARIETAL_WORDS[m.group(0)], text)
+    text = _RE_VARIETAL.sub(lambda m: _VARIETAL_WORDS[m.group(0)], text)
 
     # 13. Remaining punctuation
-    text = _NON_WORD.sub(" ", text)
+    text = _RE_NON_WORD.sub(" ", text)
 
     # 14. Final whitespace collapse
-    return _WHITESPACE.sub(" ", text).strip()
+    return _RE_WHITESPACE.sub(" ", text).strip()

--- a/src/licenseid/similarity.py
+++ b/src/licenseid/similarity.py
@@ -12,7 +12,6 @@ AggregatedLicenseMatcher.
 """
 
 import math
-from typing import Optional
 
 from rapidfuzz import fuzz
 
@@ -29,7 +28,7 @@ PROBE_WORDS: int = 60  # probe sample size (words, taken from query middle)
 PROBE_GATE: float = 0.52  # min probe score to run the full alignment scan
 
 
-def build_probe(query_words: list[str]) -> Optional[str]:
+def build_probe(query_words: list[str]) -> str | None:
     """Build the mid-query probe sample used by fragment_similarity().
 
     Only useful when the query is long enough that the probe is a real
@@ -47,7 +46,7 @@ def build_probe(query_words: list[str]) -> Optional[str]:
 def fragment_similarity(
     norm_input: str,
     search_text: str,
-    probe: Optional[str],
+    probe: str | None,
 ) -> tuple[float, str]:
     """Similarity for fragment inputs (query shorter than candidate).
 
@@ -89,7 +88,7 @@ def calculate_base_similarity(
     q_len: int,
     q_tokens: set[str],
     cand: CandidateMatch,
-    probe: Optional[str] = None,
+    probe: str | None = None,
 ) -> tuple[float, float, str]:
     """Calculate base similarity and coverage for a candidate."""
     search_text = cand.get("search_text") or ""

--- a/src/licenseid/spdx_source.py
+++ b/src/licenseid/spdx_source.py
@@ -15,7 +15,7 @@ parsed data, so they can be reasoned about and tested without a database.
 import csv
 import io
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import requests
@@ -39,8 +39,8 @@ def is_cache_valid(path: Path, days: int) -> bool:
     """Check if the cache file exists and is not older than 'days'."""
     if not path.exists():
         return False
-    mtime = datetime.fromtimestamp(path.stat().st_mtime)
-    return datetime.now() - mtime < timedelta(days=days)
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    return datetime.now(timezone.utc) - mtime < timedelta(days=days)
 
 
 def get_version_info(
@@ -102,8 +102,7 @@ def get_tarball_path(
             resp = requests.get(tar_url, stream=True, timeout=60)
             resp.raise_for_status()
             with open(tar_cache_path, "wb") as f:
-                for chunk in resp.iter_content(chunk_size=8192):
-                    f.write(chunk)
+                f.writelines(resp.iter_content(chunk_size=8192))
         except requests.RequestException as e:
             raise RuntimeError(f"Error downloading {tar_url}: {e}") from e
     else:

--- a/src/licenseid/spdx_source.py
+++ b/src/licenseid/spdx_source.py
@@ -17,7 +17,6 @@ import io
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
 
 import requests
 
@@ -45,8 +44,8 @@ def is_cache_valid(path: Path, days: int) -> bool:
 
 
 def get_version_info(
-    cache_dir: Path, version: Optional[str], use_cache: bool
-) -> tuple[str, Optional[str], str]:
+    cache_dir: Path, version: str | None, use_cache: bool
+) -> tuple[str, str | None, str]:
     """Determine target version and fetch version info."""
     licenses_json_path = cache_dir / CACHE_LICENSES_JSON
     latest_version = None
@@ -114,7 +113,7 @@ def get_tarball_path(
 
 
 def fetch_popularity_data(
-    cache_dir: Path, local_path: Optional[Path] = None
+    cache_dir: Path, local_path: Path | None = None
 ) -> dict[str, int]:
     """Fetch and aggregate popularity data from GitHub Innovation Graph."""
     popularity_map: dict[str, int] = {}

--- a/src/licenseid/types.py
+++ b/src/licenseid/types.py
@@ -8,6 +8,7 @@ Type definitions for licenseid.
 """
 
 from typing import TypedDict
+
 from typing_extensions import Required
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ Shared test configuration and fixtures for licenseid.
 """
 
 import os
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 import pytest
 

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -10,7 +10,7 @@ Accuracy and performance benchmark tests for license identification.
 
 import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 import sqlite3
 
 import pytest
@@ -132,8 +132,8 @@ MUST_HAVE_LICENSES = [
 def run_accuracy_test(
     matcher: AggregatedLicenseMatcher,
     rates: List[str],
-    max_licenses: Optional[int] = None,
-    license_ids: Optional[List[str]] = None,
+    max_licenses: int | None = None,
+    license_ids: List[str] | None = None,
 ) -> Dict[str, Dict[str, int]]:
     """Execute matching across multiple distortion rates and aggregate results."""
     results = {rate: {"total": 0, "top1": 0, "top3": 0, "top5": 0} for rate in rates}

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -9,16 +9,14 @@ Accuracy and performance benchmark tests for license identification.
 # pylint: disable=duplicate-code
 
 import json
-from pathlib import Path
-from typing import Dict, List
 import sqlite3
+from pathlib import Path
 
 import pytest
 
-from licenseid.matcher import AggregatedLicenseMatcher
 from licenseid.database import LicenseDatabase
+from licenseid.matcher import AggregatedLicenseMatcher
 from licenseid.normalize import normalize_text
-
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "license-text-long"
 
@@ -33,7 +31,7 @@ def matcher() -> AggregatedLicenseMatcher:
     db_path = "file:test_benchmark?mode=memory&cache=shared"
 
     # Keep a reference to the manager to ensure the in-memory DB is kept alive
-    db_manager = LicenseDatabase(db_path)  # pylint: disable=unused-variable # noqa: F841
+    db_manager = LicenseDatabase(db_path)  # pylint: disable=unused-variable
 
     # Populate the database with our fixtures
     fixtures = list(FIXTURES_DIR.glob("*.json"))
@@ -131,10 +129,10 @@ MUST_HAVE_LICENSES = [
 
 def run_accuracy_test(
     matcher: AggregatedLicenseMatcher,
-    rates: List[str],
+    rates: list[str],
     max_licenses: int | None = None,
-    license_ids: List[str] | None = None,
-) -> Dict[str, Dict[str, int]]:
+    license_ids: list[str] | None = None,
+) -> dict[str, dict[str, int]]:
     """Execute matching across multiple distortion rates and aggregate results."""
     results = {rate: {"total": 0, "top1": 0, "top3": 0, "top5": 0} for rate in rates}
 

--- a/tests/test_api_explicit.py
+++ b/tests/test_api_explicit.py
@@ -7,7 +7,8 @@
 # pylint: disable=redefined-outer-name,duplicate-code,missing-function-docstring
 
 import sqlite3
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 
@@ -41,8 +42,10 @@ def test_db() -> Generator[str, None, None]:
             "INSERT INTO license_index (license_id, search_text) VALUES (?, ?)",
             (
                 "MIT",
-                "permission is hereby granted free of charge to any person "
-                "obtaining a copy",
+                (
+                    "permission is hereby granted free of charge to any person "
+                    "obtaining a copy"
+                ),
             ),
         )
         conn.execute(

--- a/tests/test_cli_smart.py
+++ b/tests/test_cli_smart.py
@@ -8,7 +8,8 @@
 
 import sqlite3
 import uuid
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 from click.testing import CliRunner
@@ -35,8 +36,10 @@ def test_db() -> Generator[str, None, None]:
             "INSERT INTO license_index (license_id, search_text) VALUES (?, ?)",
             (
                 "MIT",
-                "permission is hereby granted free of charge to any person "
-                "obtaining a copy",
+                (
+                    "permission is hereby granted free of charge to any person "
+                    "obtaining a copy"
+                ),
             ),
         )
         conn.execute(

--- a/tests/test_cli_staleness.py
+++ b/tests/test_cli_staleness.py
@@ -1,0 +1,89 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for cli.check_db_staleness()."""
+# pylint: disable=redefined-outer-name
+
+import sqlite3
+import uuid
+from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from licenseid.cli import check_db_staleness
+from licenseid.database import LicenseDatabase
+
+
+def _make_db(last_check_datetime: str) -> Generator[LicenseDatabase, None, None]:
+    db_id = str(uuid.uuid4())[:8]
+    db_path = f"file:test_staleness_{db_id}?mode=memory&cache=shared"
+    db_manager = LicenseDatabase(db_path)
+    keep_alive = sqlite3.connect(db_path, uri=True)
+
+    with sqlite3.connect(db_path, uri=True) as conn:
+        conn.execute(
+            "INSERT INTO db_metadata (key, value) VALUES (?, ?)",
+            ("last_check_datetime", last_check_datetime),
+        )
+        conn.commit()
+
+    yield db_manager
+    keep_alive.close()
+
+
+@pytest.fixture
+def fresh_db() -> Generator[LicenseDatabase, None, None]:
+    now = datetime.now(timezone.utc).isoformat()
+    yield from _make_db(now)
+
+
+@pytest.fixture
+def stale_tz_aware_db() -> Generator[LicenseDatabase, None, None]:
+    old = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
+    yield from _make_db(old)
+
+
+@pytest.fixture
+def stale_naive_db() -> Generator[LicenseDatabase, None, None]:
+    """Mimics a database written before last_check_datetime became
+    tz-aware: a naive local-time ISO string with no UTC offset."""
+    old_naive = (datetime.now() - timedelta(days=200)).isoformat()  # noqa: DTZ005
+    yield from _make_db(old_naive)
+
+
+@pytest.fixture
+def malformed_db() -> Generator[LicenseDatabase, None, None]:
+    yield from _make_db("not-a-real-timestamp")
+
+
+def test_fresh_db_no_warning(
+    fresh_db: LicenseDatabase, capsys: pytest.CaptureFixture
+) -> None:
+    check_db_staleness(fresh_db)
+    assert "WARNING" not in capsys.readouterr().err
+
+
+def test_stale_tz_aware_db_warns(
+    stale_tz_aware_db: LicenseDatabase, capsys: pytest.CaptureFixture
+) -> None:
+    check_db_staleness(stale_tz_aware_db)
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_stale_naive_db_warns_without_crashing(
+    stale_naive_db: LicenseDatabase, capsys: pytest.CaptureFixture
+) -> None:
+    """Regression test: a pre-existing naive-timestamp database must not
+    raise TypeError when compared against a tz-aware datetime.now()."""
+    check_db_staleness(stale_naive_db)
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_malformed_timestamp_ignored(
+    malformed_db: LicenseDatabase, capsys: pytest.CaptureFixture
+) -> None:
+    check_db_staleness(malformed_db)
+    assert capsys.readouterr().err == ""

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -99,9 +99,13 @@ def test_normalize_deprecated_with(db: LicenseDatabase) -> None:
 
 
 def test_normalize_expression(db: LicenseDatabase) -> None:
-    """Normalise SPDX expression strings."""
-    assert normalize_identifier("MIT AND Apache-2.0", db) == "MIT AND Apache-2.0"
-    assert normalize_identifier("(MIT OR Apache-2.0)", db) == "(MIT OR Apache-2.0)"
+    """Normalise SPDX expression strings.
+
+    Operand order is canonicalised (alphabetical) by the structural
+    AND/OR sort pass, not preserved verbatim from the input.
+    """
+    assert normalize_identifier("MIT AND Apache-2.0", db) == "Apache-2.0 AND MIT"
+    assert normalize_identifier("(MIT OR Apache-2.0)", db) == "Apache-2.0 OR MIT"
     assert (
         normalize_identifier("GPL-2.0 WITH Linux-syscall-note", db)
         == "GPL-2.0-only WITH Linux-syscall-note"
@@ -109,19 +113,53 @@ def test_normalize_expression(db: LicenseDatabase) -> None:
 
 
 def test_normalize_expression_complex(db: LicenseDatabase) -> None:
-    """Normalise complex SPDX expressions with multiple operators."""
+    """Normalise complex SPDX expressions with multiple operators.
+
+    The parens around the AND subexpression are semantically redundant
+    (AND binds tighter than OR) and are dropped by canonicalisation.
+    """
     expr = "(GPL-2.0+ AND MIT) OR Apache-2.0"
-    expected = "(GPL-2.0-or-later AND MIT) OR Apache-2.0"
+    expected = "GPL-2.0-or-later AND MIT OR Apache-2.0"
     assert normalize_identifier(expr, db) == expected
 
 
 def test_normalize_case_insensitivity(db: LicenseDatabase) -> None:
     """Normalise case-insensitive SPDX expressions to canonical casing."""
-    assert normalize_identifier("mit and apache-2.0", db) == "MIT AND Apache-2.0"
+    assert normalize_identifier("mit and apache-2.0", db) == "Apache-2.0 AND MIT"
     assert (
         normalize_identifier("GPL-2.0 with Linux-syscall-note", db)
         == "GPL-2.0-only WITH Linux-syscall-note"
     )
+
+
+def test_normalize_expression_dedup(db: LicenseDatabase) -> None:
+    """Structurally identical AND/OR operands collapse to one (issue #18)."""
+    assert normalize_identifier("(MIT AND MIT)", db) == "MIT"
+    assert normalize_identifier("(MIT OR MIT)", db) == "MIT"
+    assert (
+        normalize_identifier("(MIT AND Apache-2.0) AND (Apache-2.0 AND MIT)", db)
+        == "Apache-2.0 AND MIT"
+    )
+
+
+def test_normalize_with_exception_casing(db: LicenseDatabase) -> None:
+    """The WITH right-hand side is looked up as an exception, not a license.
+
+    Regression test: previously the exception ID after WITH was normalised
+    with the license-oriented lookup, which never matched the exceptions
+    table, so a mis-cased exception ID passed through unchanged.
+    """
+    assert (
+        normalize_identifier("GPL-2.0-only WITH linux-syscall-note", db)
+        == "GPL-2.0-only WITH Linux-syscall-note"
+    )
+
+
+def test_normalize_expression_plus_fallback(db: LicenseDatabase) -> None:
+    """Expressions with a literal '+' (no '-or-later' variant) can't be
+    parsed by py_spdx_license and fall back to the pre-canonicalisation
+    string instead of raising or dropping content."""
+    assert normalize_identifier("CDDL-1.0+ AND MIT", db) == "CDDL-1.0+ AND MIT"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -14,6 +14,7 @@ import pytest
 from licenseid.database import LicenseDatabase
 from licenseid.identifiers import (
     _MAX_CANONICALIZE_OPERATORS,
+    _is_expression,
     disambiguate_deprecated_id,
     normalize_identifier,
 )
@@ -153,6 +154,31 @@ def test_normalize_expression_does_not_split_embedded_operator_words(
         normalize_identifier("GPL-2.0-or-later AND MIT", db)
         == "GPL-2.0-or-later AND MIT"
     )
+
+
+@pytest.mark.parametrize(
+    "identifier, expected",
+    [
+        # single IDs: not expressions, even though they contain AND/OR/WITH
+        # as a substring of their own name.
+        ("MIT", False),
+        ("GPL-2.0-or-later", False),
+        ("GPL-2.0-with-font-exception", False),
+        ("LicenseRef-BRANDing-1.0", False),
+        # real expressions: genuine operators, "+", or parentheses.
+        ("MIT AND Apache-2.0", True),
+        ("MIT OR Apache-2.0", True),
+        ("MIT WITH Font-exception-2.0", True),
+        ("Apache-2.0+", True),
+        ("(MIT)", True),
+    ],
+)
+def test_is_expression(identifier: str, expected: bool) -> None:
+    """_is_expression must not misfire on single IDs containing "and"/"or"/
+    "with" as a substring (regression: normalize_identifier's top-level
+    dispatch used to do a plain substring check, routing such IDs through
+    the full expression-normalisation pipeline unnecessarily)."""
+    assert _is_expression(identifier) is expected
 
 
 def test_normalize_expression_dedup(db: LicenseDatabase) -> None:

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -12,7 +12,11 @@ import pytest
 
 # pylint: disable=redefined-outer-name
 from licenseid.database import LicenseDatabase
-from licenseid.identifiers import disambiguate_deprecated_id, normalize_identifier
+from licenseid.identifiers import (
+    _MAX_CANONICALIZE_OPERATORS,
+    disambiguate_deprecated_id,
+    normalize_identifier,
+)
 
 
 @pytest.fixture
@@ -162,6 +166,24 @@ def test_normalize_expression_plus_fallback(db: LicenseDatabase) -> None:
     assert normalize_identifier("CDDL-1.0+ AND MIT", db) == "CDDL-1.0+ AND MIT"
 
 
+def test_normalize_expression_skips_canonicalization_when_large() -> None:
+    """Expressions past _MAX_CANONICALIZE_OPERATORS skip the py_spdx_license
+    sort() pass entirely instead of paying its (observed super-linear) cost.
+
+    Uses LicenseRef- IDs (no DB needed) so this stays a fast, deterministic
+    unit test rather than a timing-based one.
+    """
+    n = _MAX_CANONICALIZE_OPERATORS + 2
+    expr = " AND ".join(f"LicenseRef-{i}" for i in range(n))
+    # Capped: returned unchanged (not deduplicated/reordered), since there
+    # are no duplicates to begin with in this input.
+    assert normalize_identifier(expr, None) == expr
+
+    small_expr = "LicenseRef-B AND LicenseRef-A"
+    # Under the cap: still canonicalised (reordered).
+    assert normalize_identifier(small_expr, None) == "LicenseRef-A AND LicenseRef-B"
+
+
 @pytest.mark.parametrize(
     "text, expected",
     [
@@ -173,8 +195,16 @@ def test_normalize_expression_plus_fallback(db: LicenseDatabase) -> None:
         ("GPL-2.0 or newer", "GPL-2.0-or-later"),
         # only prose
         ("GPL-2.0 only", "GPL-2.0-only"),
+        # sentence-ending punctuation directly after the bare ID (no space)
+        # must not block matching the disambiguating phrase later on.
+        ("Licensed under GPL-2.0. This version only, not later.", "GPL-2.0-only"),
         # no disambiguating phrase — returns None
         ("GPL-2.0", None),
+        # already-canonical suffixed IDs must not be re-matched as the bare
+        # ID via their "-only"/"-or-later" suffix (regression: the bare-ID
+        # boundary check must not treat "-" as a non-continuing boundary).
+        ("GPL-2.0-only", None),
+        ("GPL-2.0-or-later", None),
         # no deprecated ID present
         ("MIT", None),
         # normalize_identifier must apply the prose check too

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -136,6 +136,25 @@ def test_normalize_case_insensitivity(db: LicenseDatabase) -> None:
     )
 
 
+def test_normalize_expression_does_not_split_embedded_operator_words(
+    db: LicenseDatabase,
+) -> None:
+    """A real ID that contains "or"/"with" as a substring (e.g. the
+    "-or-later" suffix) must tokenise as one identifier, not get split on
+    the embedded operator word.
+
+    The tokenizer regex lists AND/OR/WITH as alternatives before the
+    catch-all identifier pattern, but the catch-all's greedy "+" always
+    consumes a full contiguous run of identifier characters starting from
+    its first character, so "GPL-2.0-or-later" is matched whole before the
+    engine ever considers "or" as a standalone alternative partway through.
+    """
+    assert (
+        normalize_identifier("GPL-2.0-or-later AND MIT", db)
+        == "GPL-2.0-or-later AND MIT"
+    )
+
+
 def test_normalize_expression_dedup(db: LicenseDatabase) -> None:
     """Structurally identical AND/OR operands collapse to one (issue #18)."""
     assert normalize_identifier("(MIT AND MIT)", db) == "MIT"
@@ -195,9 +214,10 @@ def test_normalize_expression_skips_canonicalization_when_large() -> None:
         ("GPL-2.0 or newer", "GPL-2.0-or-later"),
         # only prose
         ("GPL-2.0 only", "GPL-2.0-only"),
-        # sentence-ending punctuation directly after the bare ID (no space)
-        # must not block matching the disambiguating phrase later on.
+        # sentence-ending/list punctuation directly after the bare ID (no
+        # space) must not block matching the disambiguating phrase later on.
         ("Licensed under GPL-2.0. This version only, not later.", "GPL-2.0-only"),
+        ("Licensed under GPL-2.0, or any later version.", "GPL-2.0-or-later"),
         # no disambiguating phrase — returns None
         ("GPL-2.0", None),
         # already-canonical suffixed IDs must not be re-matched as the bare

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -165,6 +165,13 @@ def test_normalize_expression_does_not_split_embedded_operator_words(
         ("GPL-2.0-or-later", False),
         ("GPL-2.0-with-font-exception", False),
         ("LicenseRef-BRANDing-1.0", False),
+        # malformed multi-word garbage with no genuine reserved token: not
+        # an expression either — must stay on the single-ID passthrough
+        # path rather than being reformatted by _normalize_expression.
+        ("n M z", False),
+        ("   ", False),
+        ("***", False),
+        ("", False),
         # real expressions: genuine operators, "+", or parentheses.
         ("MIT AND Apache-2.0", True),
         ("MIT OR Apache-2.0", True),
@@ -177,8 +184,21 @@ def test_is_expression(identifier: str, expected: bool) -> None:
     """_is_expression must not misfire on single IDs containing "and"/"or"/
     "with" as a substring (regression: normalize_identifier's top-level
     dispatch used to do a plain substring check, routing such IDs through
-    the full expression-normalisation pipeline unnecessarily)."""
+    the full expression-normalisation pipeline unnecessarily), nor on
+    malformed input with no genuine reserved token at all (regression:
+    an early version of the tokenizer-based fix treated "more than one
+    token" as sufficient, which misfired on garbage like "n M z" or
+    whitespace-only input)."""
     assert _is_expression(identifier) is expected
+
+
+def test_normalize_identifier_garbage_passthrough(db: LicenseDatabase) -> None:
+    """Whitespace-only, symbol-only, or otherwise unrecognised input passes
+    through unchanged rather than being reformatted or emptied out by
+    _normalize_expression."""
+    assert normalize_identifier("   ", db) == "   "
+    assert normalize_identifier("***", db) == "***"
+    assert normalize_identifier("n M z", db) == "n M z"
 
 
 def test_normalize_expression_dedup(db: LicenseDatabase) -> None:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -8,7 +8,7 @@
 
 import sqlite3
 import uuid
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 
@@ -39,8 +39,10 @@ def test_db() -> Generator[str, None, None]:
             "INSERT INTO license_index (license_id, search_text) VALUES (?, ?)",
             (
                 "MIT",
-                "permission is hereby granted free of charge to any person "
-                "obtaining a copy",
+                (
+                    "permission is hereby granted free of charge to any person "
+                    "obtaining a copy"
+                ),
             ),
         )
         conn.execute(

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -135,3 +135,18 @@ def test_match_with_expression_unknown_exception(test_db: str) -> None:
     matcher = AggregatedLicenseMatcher(test_db)
 
     assert matcher.match(license_id="MIT WITH Not-A-Real-Exception") == []
+
+
+def test_match_pathological_expression_does_not_crash(test_db: str) -> None:
+    """A very long AND-chain passed as license_id must degrade to "no
+    match", not crash.
+
+    Regression test: py_spdx_license's AST construction is a plain
+    recursive tree walk with no depth guard, so a long enough chain raises
+    RecursionError (not ParseError) — _match_with_expression previously
+    only caught ParseError, so this propagated out of match() uncaught.
+    """
+    matcher = AggregatedLicenseMatcher(test_db)
+    expr = " AND ".join(f"LicenseRef-{i}" for i in range(400))
+
+    assert matcher.match(license_id=expr) == []

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -99,6 +99,21 @@ def test_short_text_rejection(test_db: str) -> None:
     assert not matcher.match("   ")
     assert not matcher.match("\n\n")
 
+    # Generic short string (should fail name matching because threshold is 90/85)
+    assert not matcher.match("This")
+    assert not matcher.match("Copyright 2024.")
+    assert not matcher.match("One two three four")
+
+    # Exact name matches (< 12 words)
+    res_mit = matcher.match("MIT")
+    assert res_mit and res_mit[0]["license_id"] == "MIT"
+    res_aml = matcher.match("Apple MIT License")
+    assert res_aml and res_aml[0]["license_id"] == "AML"
+
+    # Partial name matches (< 12 words)
+    res_apple = matcher.match("APPLE PUBLIC SOURCE LICENSE")
+    assert len(res_apple) > 0 and res_apple[0]["license_id"] == "APSL-2.0"
+
 
 def test_match_with_expression(test_db: str) -> None:
     """A well-formed 'license WITH exception' expression is a real match,
@@ -120,18 +135,3 @@ def test_match_with_expression_unknown_exception(test_db: str) -> None:
     matcher = AggregatedLicenseMatcher(test_db)
 
     assert matcher.match(license_id="MIT WITH Not-A-Real-Exception") == []
-
-    # Generic short string (should fail name matching because threshold is 90/85)
-    assert not matcher.match("This")
-    assert not matcher.match("Copyright 2024.")
-    assert not matcher.match("One two three four")
-
-    # Exact name matches (< 12 words)
-    res_mit = matcher.match("MIT")
-    assert res_mit and res_mit[0]["license_id"] == "MIT"
-    res_aml = matcher.match("Apple MIT License")
-    assert res_aml and res_aml[0]["license_id"] == "AML"
-
-    # Partial name matches (< 12 words)
-    res_apple = matcher.match("APPLE PUBLIC SOURCE LICENSE")
-    assert len(res_apple) > 0 and res_apple[0]["license_id"] == "APSL-2.0"

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -134,7 +134,7 @@ def test_match_with_expression_unknown_exception(test_db: str) -> None:
     isn't in the (live-downloaded) exceptions table is not a match."""
     matcher = AggregatedLicenseMatcher(test_db)
 
-    assert matcher.match(license_id="MIT WITH Not-A-Real-Exception") == []
+    assert not matcher.match(license_id="MIT WITH Not-A-Real-Exception")
 
 
 def test_match_pathological_expression_does_not_crash(test_db: str) -> None:
@@ -149,4 +149,4 @@ def test_match_pathological_expression_does_not_crash(test_db: str) -> None:
     matcher = AggregatedLicenseMatcher(test_db)
     expr = " AND ".join(f"LicenseRef-{i}" for i in range(400))
 
-    assert matcher.match(license_id=expr) == []
+    assert not matcher.match(license_id=expr)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -9,7 +9,7 @@
 import os
 import sqlite3
 import uuid
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -49,6 +49,11 @@ def test_db() -> Generator[str, None, None]:
             ("MIT", mit_text),
         )
         conn.execute(
+            "INSERT INTO exceptions (exception_id, name, is_deprecated, superseded_by) "
+            "VALUES (?, ?, ?, ?)",
+            ("Font-exception-2.0", "Font exception 2.0", False, None),
+        )
+        conn.execute(
             "INSERT INTO db_metadata (key, value) VALUES (?, ?)",
             ("last_check_datetime", "2026-01-01T00:00:00"),
         )
@@ -93,6 +98,28 @@ def test_short_text_rejection(test_db: str) -> None:
     assert not matcher.match("")
     assert not matcher.match("   ")
     assert not matcher.match("\n\n")
+
+
+def test_match_with_expression(test_db: str) -> None:
+    """A well-formed 'license WITH exception' expression is a real match,
+    not just a literal DB row lookup (there is no such row)."""
+    matcher = AggregatedLicenseMatcher(test_db)
+
+    results = matcher.match(license_id="MIT WITH Font-exception-2.0")
+    assert len(results) == 1
+    assert results[0]["license_id"] == "MIT WITH Font-exception-2.0"
+    assert results[0]["score"] == 1.0
+    assert results[0]["is_spdx"] is True
+
+    assert matcher.is_spdx(license_id="MIT WITH Font-exception-2.0")
+
+
+def test_match_with_expression_unknown_exception(test_db: str) -> None:
+    """An otherwise well-formed WITH expression naming an exception that
+    isn't in the (live-downloaded) exceptions table is not a match."""
+    matcher = AggregatedLicenseMatcher(test_db)
+
+    assert matcher.match(license_id="MIT WITH Not-A-Real-Exception") == []
 
     # Generic short string (should fail name matching because threshold is 90/85)
     assert not matcher.match("This")

--- a/tests/test_mixed_content.py
+++ b/tests/test_mixed_content.py
@@ -9,8 +9,8 @@
 import json
 import sqlite3
 import uuid
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 import pytest
 
@@ -26,8 +26,7 @@ def test_db() -> Generator[str, None, None]:
     db_id = str(uuid.uuid4())[:8]
     db_path = f"file:test_real_{db_id}?mode=memory&cache=shared"
 
-    # pylint: disable=unused-variable
-    db_manager = LicenseDatabase(db_path)  # noqa: F841
+    db_manager = LicenseDatabase(db_path)  # pylint: disable=unused-variable # noqa: F841
     keep_alive = sqlite3.connect(db_path, uri=True)
 
     with sqlite3.connect(db_path, uri=True) as conn:

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -8,7 +8,7 @@
 
 import sqlite3
 import uuid
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 
@@ -48,8 +48,10 @@ def test_db() -> Generator[str, None, None]:
             "INSERT INTO license_index (license_id, search_text) VALUES (?, ?)",
             (
                 "MIT",
-                "permission is hereby granted free of charge to any person "
-                "obtaining a copy",
+                (
+                    "permission is hereby granted free of charge to any person "
+                    "obtaining a copy"
+                ),
             ),
         )
         conn.execute(

--- a/tests/test_spdx_source.py
+++ b/tests/test_spdx_source.py
@@ -1,0 +1,30 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for spdx_source.is_cache_valid()."""
+
+import os
+import time
+from pathlib import Path
+
+from licenseid.spdx_source import is_cache_valid
+
+
+def test_missing_file_is_invalid(tmp_path: Path) -> None:
+    assert not is_cache_valid(tmp_path / "does-not-exist.json", days=45)
+
+
+def test_fresh_file_is_valid(tmp_path: Path) -> None:
+    cache_file = tmp_path / "licenses.json"
+    cache_file.write_text("{}")
+    assert is_cache_valid(cache_file, days=45)
+
+
+def test_old_file_is_invalid(tmp_path: Path) -> None:
+    cache_file = tmp_path / "licenses.json"
+    cache_file.write_text("{}")
+    old_time = time.time() - 46 * 86400
+    os.utime(cache_file, (old_time, old_time))
+    assert not is_cache_valid(cache_file, days=45)


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for SPDX license expressions, including structural canonicalization via `py-spdx-license`. It enables proper parsing, normalization, and matching of complex expressions with `AND`/`OR`/`WITH` operators, with deduplication of identical operands and consistent operand ordering.

## Key Changes

### Expression Parsing & Normalization (`src/licenseid/identifiers.py`)
- Added `_tokenize_expression()` to properly tokenize SPDX expressions, ensuring embedded operator words (e.g., "or" in "GPL-2.0-or-later") aren't incorrectly split
- Added `_is_expression()` to distinguish genuine SPDX expressions from single IDs containing operator substrings
- Added `_normalize_exception_id()` to handle exception ID normalization separately from license IDs (exceptions have their own DB table)
- Added `_canonicalize_expression()` to perform structural AST-based canonicalization via `py_spdx_license`, with graceful fallback on parse failures
- Added `_MAX_CANONICALIZE_OPERATORS` cap (40) to skip canonicalization on pathologically large expressions to avoid super-linear performance degradation
- Updated `_normalize_expression()` to:
  - Use tokenizer-based expression detection instead of substring checks
  - Properly handle `WITH` operator by routing exception IDs to `_normalize_exception_id()`
  - Call `_canonicalize_expression()` for expressions under the operator cap
- Fixed `disambiguate_deprecated_id()` regex to use `(?![\w-])` instead of just `\b` to prevent matching bare IDs as prefixes of already-canonical suffixed IDs (e.g., "GPL-2.0" inside "GPL-2.0-only")

### Regex Naming Consistency (`src/licenseid/normalize.py`, `src/licenseid/markers.py`)
- Renamed all module-level regex patterns to use `_RE_` prefix for consistency:
  - `_HTML_TAG` → `_RE_HTML_TAG`
  - `_WHITESPACE` → `_RE_WHITESPACE`
  - `_NON_WORD` → `_RE_NON_WORD`
  - `_DASHES` → `_RE_DASHES`
  - `_QUOTES` → `_RE_QUOTES`
  - `_COMMENT_PREFIX` → `_RE_COMMENT_PREFIX`
  - `_LINE_COMMENT_PREFIX` → `_RE_LINE_COMMENT_PREFIX`
  - `_BLOCK_COMMENT_CLOSER` → `_RE_BLOCK_COMMENT_CLOSER`
  - `_SEPARATOR` → `_RE_SEPARATOR`
  - `_BULLETS` → `_RE_BULLETS`
  - `_VARIETAL_RE` → `_RE_VARIETAL`
  - `_COPYRIGHT_SYMBOL` → `_RE_COPYRIGHT_SYMBOL`
  - `_COPYRIGHT_NOTICE` → `_RE_COPYRIGHT_NOTICE`
  - `_HTTPS` → `_RE_HTTPS`
  - `_OR_LATER_RE` → `_RE_OR_LATER`
  - `_ONLY_RE` → `_RE_ONLY`
  - Similar updates in `markers.py` for all regex patterns

### Matcher Enhancement (`src/licenseid/matcher.py`)
- Added `_match_with_expression()` to resolve bare `<license> WITH <exception>` expressions by:
  - Parsing the expression structurally with `py_spdx_license`
  - Validating both license and exception halves against their respective DB tables
  - Returning a synthetic `LicenseMatch` for valid combinations
  - Catching broad exceptions (including `RecursionError` from pathological inputs)
- Updated `_resolve_to_record()` to handle composite "license WITH exception" matches that don't exist as single DB rows, falling back to computed match flags

### Dependencies (`pyproject.toml`)
- Added `py-spdx-license>=0.0.1` as a new

https://claude.ai/code/session_011dwmkwPSjWUeAnep31w3x6